### PR TITLE
Changed doctrine/couchdb version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.0",
     "laravel/framework": ">=4.1.0",
-    "doctrine/couchdb": "@dev"
+    "doctrine/couchdb": "1.0.*@dev"
   },
   "require-dev": {
   },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.3.0",
     "laravel/framework": ">=4.1.0",
-    "doctrine/couchdb": "dev"
+    "doctrine/couchdb": "@dev"
   },
   "require-dev": {
   },


### PR DESCRIPTION
Seems like the only way that this will install now is to specify the version for doctrine/couchdb to be `1.0.*@dev` as specified by [Packagist](https://packagist.org/packages/doctrine/couchdb).

I'm getting `rbewley4/laravel-couchdb dev-master requires doctrine/couchdb dev -> no matching package found.` errors otherwise when attempting to install via composer.